### PR TITLE
update for v9.0-preview2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
@@ -19,7 +19,6 @@ RUN apt-get update && \
     --self-contained \
     --verbosity quiet \
     --property:PublishSingleFile=true \
-    --property:PublishTrimmed=true \
     --property:PublishReadyToRun=true \
     --property:PackAsTool=false \
     --property:DebugType=none \

--- a/build.sh
+++ b/build.sh
@@ -7,5 +7,5 @@ VERSION=${VERSION/v/}
 docker buildx build \
   -t "ghcr.io/jessenich/ilspycmd:$VERSION" \
   --load \
-  --file prerelease.Dockerfile \
+  --file Dockerfile \
   .

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2046,SC2086
 
 __main() {
-  DLL=$(realpath "./$1")
+  DLL=$(realpath "$1")
   PDB=${1//.dll/.pdb}
   OUT=$2
 
@@ -14,7 +14,7 @@ __main() {
     ${USE_PDB:+--volume $PDB:/data/in/$(basename $PDB)} \
     --volume "$OUT:/data/out" \
     --rm \
-    ghcr.io/jessenich/ilspycmd:8.0-preview4 \
+    ghcr.io/jessenich/ilspycmd:9.0-preview2 \
     --outputdir "/data/out" \
     ${USE_PDB:+--use-varnames-from-pdb} \
     ${USE_PDB:+--generate-pdb} \


### PR DESCRIPTION
Apparently trimming needs to be a project setting with the 8.0 SDK (https://github.com/dotnet/runtime/issues/94406), so I just removed the property setting to resolve the `NETSDK1124` error. Open to other solutions though.